### PR TITLE
Change the background sync to both push and pull

### DIFF
--- a/src/ios/BEMServerSyncCommunicationHelper.h
+++ b/src/ios/BEMServerSyncCommunicationHelper.h
@@ -9,9 +9,11 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
+typedef void (^SilentPushCompletionHandler)(UIBackgroundFetchResult);
+
 @interface BEMServerSyncCommunicationHelper: NSObject
 // Top level method
-+ (void) backgroundSync:(void (^)(UIBackgroundFetchResult))completionHandler;
++ (void) backgroundSync:(SilentPushCompletionHandler)completionHandler;
 
 // Wrappers around the communication methods
 + (void) pushAndClearUserCache:(void (^)(BOOL))completionHandler;


### PR DESCRIPTION
Before this, since we were focused on e-mission code, we only pushed data.
So we added a new backgroundSync method to both push and pull, but there were
some minor tweaks needed in it.
