### PR TITLE
Move the server sync init code to pluginInitialize

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,6 +37,7 @@
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="ServerSync">
         <param name="android-package" value="edu.berkeley.eecs.emission.cordova.serversync.ServerSyncPlugin"/>
+        <param name="onload" value="true"/>
       </feature>
     </config-file>
 

--- a/src/android/ServerSyncPlugin.java
+++ b/src/android/ServerSyncPlugin.java
@@ -38,22 +38,25 @@ public class ServerSyncPlugin extends CordovaPlugin {
     private static String TAG = "ServerSyncPlugin";
 
     @Override
+    protected void pluginInitialize() {
+        mAccount = GetOrCreateSyncAccount(actv); 
+        System.out.println("mAccount = "+mAccount);
+
+        // TODO: In cfc_tracker but not in e_mission. Needed?
+        mResolver = actv.getContentResolver();
+
+        // Get the content resolver for your app
+        // Turn on automatic syncing for the default account and authority
+        ContentResolver.setIsSyncable(mAccount, AUTHORITY, 1);
+        ContentResolver.setSyncAutomatically(mAccount, AUTHORITY, true);
+        ContentResolver.addPeriodicSync(mAccount, AUTHORITY, new Bundle(), SYNC_INTERVAL);
+    }
+
+    @Override
     public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
             Activity actv = cordova.getActivity();
 
         if (action.equals("init")) {
-            mAccount = GetOrCreateSyncAccount(actv); 
-            System.out.println("mAccount = "+mAccount);
-
-            // TODO: In cfc_tracker but not in e_mission. Needed?
-            mResolver = actv.getContentResolver();
-
-            // Get the content resolver for your app
-            // Turn on automatic syncing for the default account and authority
-            ContentResolver.setIsSyncable(mAccount, AUTHORITY, 1);
-            ContentResolver.setSyncAutomatically(mAccount, AUTHORITY, true);
-            ContentResolver.addPeriodicSync(mAccount, AUTHORITY, new Bundle(), SYNC_INTERVAL);
-            callbackContext.success();
             return true;
         } else if (action.equals("forceSync")) {
             Context ctxt = cordova.getActivity();

--- a/src/ios/BEMServerSyncPlugin.h
+++ b/src/ios/BEMServerSyncPlugin.h
@@ -2,13 +2,6 @@
 
 @interface BEMServerSyncPlugin: CDVPlugin <UINavigationControllerDelegate>
 
-/* 
- * Currently unused. Depending on what we choose to do wrt remote
- * notifications, visit notification, etc, here's where we will sign up for
- * events if needed.
- */
-
-- (void) init:(CDVInvokedUrlCommand*)command;
 - (void) forceSync:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/BEMServerSyncPlugin.m
+++ b/src/ios/BEMServerSyncPlugin.m
@@ -4,24 +4,6 @@
 
 @implementation BEMServerSyncPlugin
 
-- (void)init:(CDVInvokedUrlCommand*)command
-{
-    NSString* callbackId = [command callbackId];
-    @try {
-        // Currently unused
-        CDVPluginResult* result = [CDVPluginResult
-                                   resultWithStatus:CDVCommandStatus_OK];
-        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
-    }
-    @catch (NSException *exception) {
-        NSString* msg = [NSString stringWithFormat: @"While initializing, error %@", exception];
-        CDVPluginResult* result = [CDVPluginResult
-                                   resultWithStatus:CDVCommandStatus_ERROR
-                                   messageAsString:msg];
-        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
-    }
-}
-
 - (void)forceSync:(CDVInvokedUrlCommand*)command
 {
     NSString* callbackId = [command callbackId];

--- a/www/serversync.js
+++ b/www/serversync.js
@@ -2,25 +2,7 @@
 
 var exec = require("cordova/exec")
 
-/*
- * Format of the returned value:
- * {
- *    "connectUrl": "...",
- *    "isSkipAuth": true/false,
- *    "googleWebAppClientID": "...",
- *    "ios": {
- *       "googleClientID": "...",
- *       "googleClientSecret": "...",
- *       "parseAppID": "...",
- *       "parseClientID": "...",
- *    }
- * }
- */
-
 var ServerSync = {
-    init: function (config, successCallback, errorCallback) {
-        exec(successCallback, errorCallback, "ServerSync", "init", []);
-    },
     forceSync: function (successCallback, errorCallback) {
         exec(successCallback, errorCallback, "ServerSync", "forceSync", []);
     }


### PR DESCRIPTION
Instead of initializing in a separate init method that has to be called from
javascript, let's just put it into plugin initialize. This will make the
javascript initialization simpler and lead to fewer issues on iOS.
