### PR TITLE
Allow the sync interval, and by implication, the battery level, to be configured

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -82,6 +82,8 @@
     <source-file src="src/android/SyncService.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <source-file src="src/android/CommunicationHelper.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <source-file src="src/android/ServerSyncPlugin.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
+    <source-file src="src/android/ConfigManager.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
+    <source-file src="src/android/ServerSyncConfig.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <resource-file src="res/android/authenticator.xml" target="res/xml/authenticator.xml"/>
     <resource-file src="res/android/syncadapter.xml" target="res/xml/syncadapter.xml"/>
   </platform>
@@ -99,8 +101,12 @@
     <header-file src="src/ios/BEMActivitySync.h" target-dir="BEMServerSync"/>
     <header-file src="src/ios/BEMServerSyncCommunicationHelper.h" target-dir="BEMServerSync"/>
     <header-file src="src/ios/BEMServerSyncPlugin.h" target-dir="BEMServerSync"/>
+    <header-file src="src/ios/BEMServerSyncConfig.h" target-dir="BEMServerSync"/>
+    <header-file src="src/ios/BEMServerSyncConfigManager.h" target-dir="BEMServerSync"/>
     <source-file src="src/ios/BEMActivitySync.m" target-dir="BEMServerSync"/>
     <source-file src="src/ios/BEMServerSyncCommunicationHelper.m" target-dir="BEMServerSync"/>
     <source-file src="src/ios/BEMServerSyncPlugin.m" target-dir="BEMServerSync"/>
+    <source-file src="src/ios/BEMServerSyncConfig.m" target-dir="BEMServerSync"/>
+    <source-file src="src/ios/BEMServerSyncConfigManager.m" target-dir="BEMServerSync"/>
   </platform>
 </plugin>

--- a/src/android/ConfigManager.java
+++ b/src/android/ConfigManager.java
@@ -1,0 +1,39 @@
+package edu.berkeley.eecs.emission.cordova.serversync;
+
+import android.content.Context;
+
+import edu.berkeley.eecs.emission.R;
+import edu.berkeley.eecs.emission.cordova.serversync.ServerSyncConfig;
+import edu.berkeley.eecs.emission.cordova.usercache.UserCacheFactory;
+
+/**
+ * Created by shankari on 3/25/16.
+ */
+
+public class ConfigManager {
+    private static ServerSyncConfig cachedConfig;
+
+    public static ServerSyncConfig getConfig(Context context) {
+        if (cachedConfig == null) {
+            cachedConfig = readFromCache(context);
+            if (cachedConfig == null) {
+                // This is still NULL, which means that there is no document in the usercache.
+                // Let us set it to the default settings
+                // we don't want to save it to the database because then it will look like a user override
+                cachedConfig = new ServerSyncConfig();
+            }
+        }
+        return cachedConfig;
+    }
+
+    private static ServerSyncConfig readFromCache(Context context) {
+        return UserCacheFactory.getUserCache(context)
+                .getDocument(R.string.key_usercache_sensor_config, ServerSyncConfig.class);
+    }
+
+    protected static void updateConfig(Context context, ServerSyncConfig newConfig) {
+        UserCacheFactory.getUserCache(context)
+                .putReadWriteDocument(R.string.key_usercache_sensor_config, newConfig);
+        cachedConfig = newConfig;
+    }
+}

--- a/src/android/ConfigManager.java
+++ b/src/android/ConfigManager.java
@@ -28,12 +28,12 @@ public class ConfigManager {
 
     private static ServerSyncConfig readFromCache(Context context) {
         return UserCacheFactory.getUserCache(context)
-                .getDocument(R.string.key_usercache_sensor_config, ServerSyncConfig.class);
+                .getDocument(R.string.key_usercache_sync_config, ServerSyncConfig.class);
     }
 
     protected static void updateConfig(Context context, ServerSyncConfig newConfig) {
         UserCacheFactory.getUserCache(context)
-                .putReadWriteDocument(R.string.key_usercache_sensor_config, newConfig);
+                .putReadWriteDocument(R.string.key_usercache_sync_config, newConfig);
         cachedConfig = newConfig;
     }
 }

--- a/src/android/ServerSyncConfig.java
+++ b/src/android/ServerSyncConfig.java
@@ -1,7 +1,5 @@
 package edu.berkeley.eecs.emission.cordova.serversync;
 
-import com.google.android.gms.location.LocationRequest;
-
 import edu.berkeley.eecs.emission.cordova.tracker.Constants;
 
 /**

--- a/src/android/ServerSyncConfig.java
+++ b/src/android/ServerSyncConfig.java
@@ -1,13 +1,11 @@
 package edu.berkeley.eecs.emission.cordova.serversync;
 
-import edu.berkeley.eecs.emission.cordova.tracker.Constants;
-
 /**
  * Created by shankari on 10/20/15.
  */
 
 public class ServerSyncConfig {
-    private static final long DEFAULT_SYNC_INTERVAL = 1 * 60 * 60; // Changed to 10 secs to debug syncing issues on some android version
+    private static final long DEFAULT_SYNC_INTERVAL = 60 * 60; // Changed to 10 secs to debug syncing issues on some android version
 
     public ServerSyncConfig() {
         this.sync_interval = DEFAULT_SYNC_INTERVAL;
@@ -20,4 +18,5 @@ public class ServerSyncConfig {
     // We don't need any "set" fields because the entire document will be set as a whole
     // using the javascript interface
     private long sync_interval;
+    private boolean ios_use_remote_push; // iOS only, unused
 }

--- a/src/android/ServerSyncConfig.java
+++ b/src/android/ServerSyncConfig.java
@@ -1,0 +1,25 @@
+package edu.berkeley.eecs.emission.cordova.serversync;
+
+import com.google.android.gms.location.LocationRequest;
+
+import edu.berkeley.eecs.emission.cordova.tracker.Constants;
+
+/**
+ * Created by shankari on 10/20/15.
+ */
+
+public class ServerSyncConfig {
+    private static final long DEFAULT_SYNC_INTERVAL = 1 * 60 * 60; // Changed to 10 secs to debug syncing issues on some android version
+
+    public ServerSyncConfig() {
+        this.sync_interval = DEFAULT_SYNC_INTERVAL;
+    }
+
+    public long getSyncInterval() {
+        return this.sync_interval;
+    }
+
+    // We don't need any "set" fields because the entire document will be set as a whole
+    // using the javascript interface
+    private long sync_interval;
+}

--- a/src/android/ServerSyncPlugin.java
+++ b/src/android/ServerSyncPlugin.java
@@ -14,6 +14,8 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
 
+import com.google.gson.Gson;
+
 import edu.berkeley.eecs.emission.R;
 import edu.berkeley.eecs.emission.cordova.clientstats.ClientStatsHelper;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
@@ -32,10 +34,10 @@ public class ServerSyncPlugin extends CordovaPlugin {
     // Our ContentResolver is actually a dummy - does this matter?
     ContentResolver mResolver;
     
-    private static final long SYNC_INTERVAL = 1 * 60 * 60; // Changed to 10 secs to debug syncing issues on some android version
     // END: variables to set up the automatic syncing
 
     private static String TAG = "ServerSyncPlugin";
+    private static Bundle unusedExtras = new Bundle();
 
     @Override
     protected void pluginInitialize() {
@@ -50,7 +52,7 @@ public class ServerSyncPlugin extends CordovaPlugin {
         // Turn on automatic syncing for the default account and authority
         ContentResolver.setIsSyncable(mAccount, AUTHORITY, 1);
         ContentResolver.setSyncAutomatically(mAccount, AUTHORITY, true);
-        ContentResolver.addPeriodicSync(mAccount, AUTHORITY, new Bundle(), SYNC_INTERVAL);
+        restartSync(actv);
     }
 
     @Override
@@ -85,10 +87,31 @@ public class ServerSyncPlugin extends CordovaPlugin {
             };
             task.execute(actv);
             return true;
+        } else if (action.equals("getConfig")) {
+            Context ctxt = cordova.getActivity();
+            ServerSyncConfig cfg = ConfigManager.getConfig(ctxt);
+            // Gson.toJson() represents a string and we are expecting an object in the interface
+            callbackContext.success(new JSONObject(new Gson().toJson(cfg)));
+            return true;
+        } else if (action.equals("setConfig")) {
+            Context ctxt = cordova.getActivity();
+            JSONObject newConfig = data.getJSONObject(0);
+            ServerSyncConfig cfg = new Gson().fromJson(newConfig.toString(), ServerSyncConfig.class);
+            ConfigManager.updateConfig(ctxt, cfg);
+            restartSync(ctxt);
+            callbackContext.success();
+            return true;
+
         } else {
             return false;
         }
     }
+
+    protected void restartSync(Context ctxt) {
+        ContentResolver.addPeriodicSync(mAccount, AUTHORITY, unusedExtras,
+                ConfigManager.getConfig(ctxt).getSyncInterval());
+    }
+
 
     public static Account GetOrCreateSyncAccount(Context context) {
     	// Get an instance of the Android account manager

--- a/src/android/ServerSyncPlugin.java
+++ b/src/android/ServerSyncPlugin.java
@@ -108,6 +108,8 @@ public class ServerSyncPlugin extends CordovaPlugin {
     }
 
     protected void restartSync(Context ctxt) {
+        System.out.println("Starting sync with interval "+
+                ConfigManager.getConfig(ctxt).getSyncInterval());
         ContentResolver.addPeriodicSync(mAccount, AUTHORITY, unusedExtras,
                 ConfigManager.getConfig(ctxt).getSyncInterval());
     }

--- a/src/ios/BEMServerSyncConfig.h
+++ b/src/ios/BEMServerSyncConfig.h
@@ -11,6 +11,6 @@
 @interface BEMServerSyncConfig : NSObject
 
 @property long sync_interval;
-@property NSString* device_token;
+@property BOOL ios_use_remote_push;
 
 @end

--- a/src/ios/BEMServerSyncConfig.h
+++ b/src/ios/BEMServerSyncConfig.h
@@ -1,0 +1,16 @@
+//
+//  SyncConfig.h
+//  emission
+//
+//  Created by Kalyanaraman Shankari on 6/21/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface BEMServerSyncConfig : NSObject
+
+@property long sync_interval;
+@property NSString* device_token;
+
+@end

--- a/src/ios/BEMServerSyncConfig.m
+++ b/src/ios/BEMServerSyncConfig.m
@@ -1,0 +1,21 @@
+//
+//  SyncConfig.m
+//  emission
+//
+//  Created by Kalyanaraman Shankari on 6/21/16.
+//
+//
+
+#import "BEMServerSyncConfig.h"
+
+// 3600 secs = 1 hour
+#define ONE_HOUR 60 * 60
+
+@implementation BEMServerSyncConfig
+
+-(id)init {
+    self.sync_interval = ONE_HOUR;
+    return self;
+}
+
+@end

--- a/src/ios/BEMServerSyncConfig.m
+++ b/src/ios/BEMServerSyncConfig.m
@@ -15,6 +15,7 @@
 
 -(id)init {
     self.sync_interval = ONE_HOUR;
+    self.ios_use_remote_push = YES;
     return self;
 }
 

--- a/src/ios/BEMServerSyncConfigManager.h
+++ b/src/ios/BEMServerSyncConfigManager.h
@@ -1,0 +1,17 @@
+//
+//  ServerSyncConfigManager.h
+//  emission
+//
+//  Created by Kalyanaraman Shankari on 6/21/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "BEMServerSyncConfig.h"
+
+@interface BEMServerSyncConfigManager : NSObject
+
++ (BEMServerSyncConfig*) instance;
++ (void) updateConfig:(BEMServerSyncConfig*) newConfig;
+
+@end

--- a/src/ios/BEMServerSyncConfigManager.m
+++ b/src/ios/BEMServerSyncConfigManager.m
@@ -1,0 +1,40 @@
+//
+//  ServerSyncConfigManager.m
+//  emission
+//
+//  Created by Kalyanaraman Shankari on 6/21/16.
+//
+//
+
+#import "BEMServerSyncConfigManager.h"
+#import "BEMBuiltinUserCache.h"
+
+#define SENSOR_CONFIG_KEY @"key.usercache.sync_config"
+
+static BEMServerSyncConfig *_instance;
+
+@implementation BEMServerSyncConfigManager
+
++ (BEMServerSyncConfig*) instance {
+    if (_instance == NULL) {
+        _instance = [self readFromCache];
+        if (_instance == NULL) {
+            // This is still NULL, which means that there is no document in the usercache.
+            // Let us add a dummy one based on the default settings
+            // we don't want to save it to the database because then it will look like a user override
+            _instance = [BEMServerSyncConfig new];
+        }
+    }
+    return _instance;
+}
+
++ (BEMServerSyncConfig*) readFromCache {
+    return (BEMServerSyncConfig*)[[BuiltinUserCache database] getDocument:SENSOR_CONFIG_KEY wrapperClass:[BEMServerSyncConfig class]];
+}
+
++ (void) updateConfig:(BEMServerSyncConfig*) newConfig {
+    [[BuiltinUserCache database] putReadWriteDocument:SENSOR_CONFIG_KEY value:newConfig];
+    _instance = newConfig;
+}
+
+@end

--- a/src/ios/BEMServerSyncPlugin.h
+++ b/src/ios/BEMServerSyncPlugin.h
@@ -2,7 +2,9 @@
 
 @interface BEMServerSyncPlugin: CDVPlugin <UINavigationControllerDelegate>
 
+- (void) pluginInitialize;
 - (void) forceSync:(CDVInvokedUrlCommand*)command;
 - (void) setConfig:(CDVInvokedUrlCommand*)command;
++ (void) applySync;
 
 @end

--- a/src/ios/BEMServerSyncPlugin.h
+++ b/src/ios/BEMServerSyncPlugin.h
@@ -3,5 +3,6 @@
 @interface BEMServerSyncPlugin: CDVPlugin <UINavigationControllerDelegate>
 
 - (void) forceSync:(CDVInvokedUrlCommand*)command;
+- (void) setConfig:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/BEMServerSyncPlugin.m
+++ b/src/ios/BEMServerSyncPlugin.m
@@ -1,6 +1,10 @@
 #import "BEMServerSyncPlugin.h"
 #import "BEMServerSyncCommunicationHelper.h"
+#import "BEMServerSyncConfig.h"
+#import "BEMServerSyncConfigManager.h"
 #import "LocalNotificationManager.h"
+#import <Parse/Parse.h>
+#import "DataUtils.h"
 
 @implementation BEMServerSyncPlugin
 
@@ -25,5 +29,58 @@
         [self.commandDelegate sendPluginResult:result callbackId:callbackId];
     }
 }
+
+- (void)getConfig:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    
+    @try {
+        BEMServerSyncConfig* cfg = [BEMServerSyncConfigManager instance];
+        NSDictionary* retDict = [DataUtils wrapperToDict:cfg];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsDictionary:retDict];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting settings, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+
+- (void)setConfig:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSDictionary* newDict = [[command arguments] objectAtIndex:0];
+        BEMServerSyncConfig* newCfg = [BEMServerSyncConfig new];
+        [DataUtils dictToWrapper:newDict wrapper:newCfg];
+        PFInstallation *currentInstallation = [PFInstallation currentInstallation];
+        // set the device token so that we know which device to change the token for
+        newCfg.device_token = currentInstallation.deviceToken;
+        [BEMServerSyncConfigManager updateConfig:newCfg];
+        // iOS sync happens through silent push notifications, so the server needs
+        // to be modified, not the client
+        // Let's set the background fetch interval though so that we can report how
+        // frequently it happens (whether we use it or not)
+        [[UIApplication sharedApplication] setMinimumBackgroundFetchInterval:[BEMServerSyncConfigManager instance].sync_interval];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While updating settings, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    
+}
+
 @end
 

--- a/www/serversync.js
+++ b/www/serversync.js
@@ -2,10 +2,28 @@
 
 var exec = require("cordova/exec")
 
+/*
+ * Format of the returned value:
+ * {
+ *    "sync_interval": 1224,
+ *    "device_token": "90c00463..." (ios only)
+ * }
+ */
+
 var ServerSync = {
     forceSync: function (successCallback, errorCallback) {
         exec(successCallback, errorCallback, "ServerSync", "forceSync", []);
-    }
+    },
+    getConfig: function () {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "ServerSync", "getConfig", []);
+        });
+    },
+    setConfig: function (newConfig) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "ServerSync", "setConfig", [newConfig]);
+        });
+    },
 }
 
 module.exports = ServerSync;


### PR DESCRIPTION
Should we decouple the two? Read only battery level and skip the actual I/O?
