### PR TITLE
Moved the timequery call to the usercache

### DIFF
--- a/src/android/ServerSyncAdapter.java
+++ b/src/android/ServerSyncAdapter.java
@@ -114,7 +114,7 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
 				System.out.println("No data to send, returning early!");
 			} else {
 				CommunicationHelper.phone_to_server(cachedContext, userToken, entriesToPush);
-				UserCache.TimeQuery tq = getTimeQuery(entriesToPush);
+				UserCache.TimeQuery tq = BuiltinUserCache.getTimeQuery(cachedContext, entriesToPush);
 				biuc.clearEntries(tq);
 			}
 		} catch (JSONException e) {
@@ -177,21 +177,6 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
          */
 		TripDiaryStateMachineReceiver.validateAndCleanupState(cachedContext);
 		TripDiaryStateMachineReceiver.saveBatteryAndSimulateUser(cachedContext);
-	}
-
-	/*
-	 * TODO: This should probably be moved into the usercache somehow
-	 */
-	public static UserCache.TimeQuery getTimeQuery(JSONArray pointList) throws JSONException {
-		long start_ts = pointList.getJSONObject(0).getJSONObject("metadata").getLong("write_ts");
-		long end_ts = pointList.getJSONObject(pointList.length() - 1).getJSONObject("metadata").getLong("write_ts");
-		// This might still have a race in which there are new entries added with the same timestamp as the last
-		// entry. Use an id instead? Or manually choose a slightly earlier ts to be on the safe side?
-		// TODO: Need to figure out which one to do
-		// Start slightly before and end slightly after to make sure that we get all entries
-		UserCache.TimeQuery tq = new UserCache.TimeQuery(R.string.metadata_usercache_write_ts,
-				start_ts - 1, end_ts + 1);
-		return tq;
 	}
 
 	/*


### PR DESCRIPTION
It makes a lot more sense there - since the timequery is usercache specific anyway.
This also makes it consistent with iOS.
And removes a TODO to boot.
