### PR TITLE
Change constructor to use singleton

### DIFF
--- a/src/android/ServerSyncAdapter.java
+++ b/src/android/ServerSyncAdapter.java
@@ -105,7 +105,7 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
 		 * We are going to send over information for all the data in a single JSON object, to avoid overhead.
 		 * So we take a quick check to see if the number of entries is zero.
 		 */
-		BuiltinUserCache biuc = new BuiltinUserCache(cachedContext);
+		BuiltinUserCache biuc = BuiltinUserCache.getDatabase(cachedContext);
 
 		Log.i(cachedContext, TAG, "Starting sync with push");
 		try {


### PR DESCRIPTION
This is a change to the only other usercache reference, consistent with
https://github.com/e-mission/cordova-usercache/pull/22/commits/68c7bd36674bc1ec33193b17c39a979a098cfd7e
