### PR TITLE
Sync changes to call the clear code correctly

### DIFF
--- a/src/android/ServerSyncAdapter.java
+++ b/src/android/ServerSyncAdapter.java
@@ -116,6 +116,7 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
 				CommunicationHelper.phone_to_server(cachedContext, userToken, entriesToPush);
 				UserCache.TimeQuery tq = BuiltinUserCache.getTimeQuery(cachedContext, entriesToPush);
 				biuc.clearEntries(tq);
+				biuc.clearSupersededRWDocs(tq);
 			}
 		} catch (JSONException e) {
 			Log.e(cachedContext, TAG, "Error "+e+" while saving converting trips to JSON, skipping all of them");
@@ -130,9 +131,12 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
          * because we want to try it even if the push fails.
          */
 		try {
+			UserCache.TimeQuery tq = new UserCache.TimeQuery("write_ts", 0, System.currentTimeMillis()/1000);
+			biuc.clearObsoleteDocs(tq);
 			JSONArray entriesReceived = edu.berkeley.eecs.emission.cordova.serversync.CommunicationHelper.server_to_phone(
 					cachedContext, userToken);
 			biuc.sync_server_to_phone(entriesReceived);
+			biuc.checkAfterPull();
 		} catch (JSONException e) {
 			Log.e(cachedContext, TAG, "Error "+e+" while saving converting trips to JSON, skipping all of them");
 		} catch (IOException e) {

--- a/src/ios/BEMServerSyncPlugin.m
+++ b/src/ios/BEMServerSyncPlugin.m
@@ -5,6 +5,7 @@
 #import "LocalNotificationManager.h"
 #import <Parse/Parse.h>
 #import "DataUtils.h"
+#import "BEMBuiltinUserCache.h"
 
 @implementation BEMServerSyncPlugin
 
@@ -18,6 +19,7 @@
     NSString* callbackId = [command callbackId];
     @try {
         [[BEMServerSyncCommunicationHelper backgroundSync] continueWithBlock:^id(BFTask *task) {
+            [[BuiltinUserCache database] checkAfterPull];
             [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                        @"all sync completed"] showUI:TRUE];
             CDVPluginResult* result = [CDVPluginResult


### PR DESCRIPTION
In
https://github.com/e-mission/cordova-usercache/pull/25/commits/f35f39a1766ee660519a7481eb05c8ac7d8be43b,
we split cleanEntries into three to better support parallel operation. This
changes the sync code to call the three calls + the check call correctly.
