### PR TITLE
Switch all client stats references to store StatsEvents into the user…

### DIFF
--- a/src/android/CommunicationHelper.java
+++ b/src/android/CommunicationHelper.java
@@ -14,16 +14,6 @@ public class CommunicationHelper {
     public static final String TAG = "CommunicationHelper";
 
     /*
-     * Pushes the stats to the host.
-     */
-    public static void pushStats(Context cachedContext, String userToken,
-                                 JSONObject appStats) throws IOException, JSONException {
-        String commuteTrackerHost = ConnectionSettings.getConnectURL(cachedContext);
-        edu.berkeley.eecs.emission.cordova.comm.CommunicationHelper.pushJSON(
-            cachedContext, commuteTrackerHost + "/stats/set", userToken, "stats", appStats);
-    }
-
-    /*
      * Gets user cache information from server
      */
 

--- a/src/android/ServerSyncPlugin.java
+++ b/src/android/ServerSyncPlugin.java
@@ -17,7 +17,6 @@ import android.os.Bundle;
 import com.google.gson.Gson;
 
 import edu.berkeley.eecs.emission.R;
-import edu.berkeley.eecs.emission.cordova.clientstats.ClientStatsHelper;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
 
 public class ServerSyncPlugin extends CordovaPlugin {
@@ -68,10 +67,6 @@ public class ServerSyncPlugin extends CordovaPlugin {
              * Calling forceSync so that we can know when the tasks is complete
              * and do a callback at that point.
              */
-            ClientStatsHelper statsHelper = new ClientStatsHelper(ctxt);
-            statsHelper.storeMeasurement(ctxt.getString(R.string.button_sync_forced), null,
-                    String.valueOf(System.currentTimeMillis()));
-
             final CallbackContext cachedCallbackContext = callbackContext;
             AsyncTask<Context, Void, Void> task = new AsyncTask<Context, Void, Void>() {
                 protected Void doInBackground(Context... ctxt) {

--- a/src/ios/BEMServerSyncCommunicationHelper.h
+++ b/src/ios/BEMServerSyncCommunicationHelper.h
@@ -19,13 +19,11 @@ typedef void (^SilentPushCompletionHandler)(UIBackgroundFetchResult);
 // Wrappers around the communication methods
 + (BFTask*) pushAndClearUserCache;
 + (BFTask*) pullIntoUserCache;
-+ (BFTask*) pushAndClearStats;
 
 // Communication methods (copied from communication handler to make it generic)
 +(void)phone_to_server:(NSArray*) entriesToPush
      completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 +(void)server_to_phone:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
-+(void)setClientStats:(NSDictionary*)statsToSend completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 
 + (NSInteger)fetchedData:(NSData *)responseData;
 @end


### PR DESCRIPTION
…cache

This is part of https://github.com/e-mission/cordova-usercache/commit/67ae0c9d8d6fe454d3dfded1a46d95b262f75aac
Note that:
- we store the sync_pull_length but not the sync_push_length. We may need to add this.
- we do not store the overall sync_duration in iOS because the calls are async
  and it is unclear how we can pass around the start time.

This also includes cleaning up the putStats wrapper from android.
The iOS wrapper was deleted in
https://github.com/e-mission/cordova-server-communication/pull/13/commits/a0d908b0a16fa3bf31fab212869f013142dc2e39