### PR TITLE
Fix the error reporting to be standard

### DIFF
--- a/www/ui/ionic/js/sync-settings.js
+++ b/www/ui/ionic/js/sync-settings.js
@@ -72,7 +72,7 @@ angular.module('emission.main.control.sync', ['emission.services'])
                 curr_sync_interval: csh.new_config.sync_interval
             });
         }).catch(function(err){
-            console.log("setConfig Error: " + err);
+            window.logger.Logger.displayError("Error while setting sync config", err);
         });
     };
 


### PR DESCRIPTION
This makes the error reporting of this code consistent with
https://github.com/e-mission/e-mission-phone/commit/11734545c7b9283beeb72c63899763091363ae98

Not bumping up the version number just for this since nobody has complained
about it. It will go out as part of the next native code change, whenever that
is.