### PR TITLE
Feature/support manual sync

### DIFF
--- a/src/android/ServerSyncConfig.java
+++ b/src/android/ServerSyncConfig.java
@@ -9,14 +9,20 @@ public class ServerSyncConfig {
 
     public ServerSyncConfig() {
         this.sync_interval = DEFAULT_SYNC_INTERVAL;
+        this.manualOnly = true;
     }
 
     public long getSyncInterval() {
         return this.sync_interval;
     }
 
+    public boolean isManual(){
+        return this.manualOnly;
+    }
+
     // We don't need any "set" fields because the entire document will be set as a whole
     // using the javascript interface
     private long sync_interval;
+    private boolean manualOnly;
     private boolean ios_use_remote_push; // iOS only, unused
 }

--- a/src/ios/BEMServerSyncConfig.h
+++ b/src/ios/BEMServerSyncConfig.h
@@ -11,6 +11,7 @@
 @interface BEMServerSyncConfig : NSObject
 
 @property long sync_interval;
+@property BOOL manualOnly;
 @property BOOL ios_use_remote_push;
 
 @end

--- a/src/ios/BEMServerSyncConfig.m
+++ b/src/ios/BEMServerSyncConfig.m
@@ -16,6 +16,7 @@
 -(id)init {
     self.sync_interval = ONE_HOUR;
     self.ios_use_remote_push = YES;
+    self.manualOnly = YES;
     return self;
 }
 

--- a/src/ios/BEMServerSyncPlugin.h
+++ b/src/ios/BEMServerSyncPlugin.h
@@ -5,6 +5,9 @@
 - (void) pluginInitialize;
 - (void) forceSync:(CDVInvokedUrlCommand*)command;
 - (void) setConfig:(CDVInvokedUrlCommand*)command;
-+ (void) applySync;
++ (void) restartSync;
++ (void) startManualSync;
++ (void) applyAutoSync;
 
 @end
+


### PR DESCRIPTION
Add support for on-demand server syncing.

According to a discussion with @stephhuerre, we have to modify the `BEMAppDelegate.m` file for the ios code to work correctly. However, I have no idea where that file is located.

The `BEMAppDelegate.m` changes from @stepphe
https://gist.github.com/ericafenyo/8e82acd06547225bfca10d45d0a7322f