### PR TITLE
Remove all references to Parse

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.serversync"
-        version="1.2.2">
+        version="1.2.3">
 
   <name>ServerSync</name>
   <description>Push and pull local data to the server</description>


### PR DESCRIPTION
Since we don't really integrate with them anyway.
This is related to
https://github.com/e-mission/e-mission-data-collection/pull/184/commits/ebe2d20e6e12d56a7045d4d2e93c61ab6cca89bf
in PR
https://github.com/e-mission/e-mission-data-collection/pull/184

Note that there appears to be a subtle bug here in which we save the sync
config but don't update the profile.  And we use the profile to determine the
frequency at which to send the IOS pushes. But that is not really related to
this change which attempted to save channels to a non-existent server.