### PR TITLE
Added server sync utility methods to be used in native codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-serversync",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Simple package that stores all the connection settings that need to be configured",
   "license": "BSD-3-clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-serversync"
-        version="1.2.5">
+        version="1.2.6">
 
   <name>ServerSync</name>
   <description>Push and pull local data to the server</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -87,6 +87,7 @@
     <source-file src="src/android/ServerSyncPlugin.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <source-file src="src/android/ConfigManager.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <source-file src="src/android/ServerSyncConfig.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
+    <source-file src="src/android/ServerSyncUtil.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <resource-file src="res/android/authenticator.xml" target="res/xml/authenticator.xml"/>
     <resource-file src="res/android/syncadapter.xml" target="res/xml/syncadapter.xml"/>
     <resource-file src="res/android/ic_mood_question.png" target="res/drawable/ic_mood_question.png"/>

--- a/src/android/ServerSyncUtil.java
+++ b/src/android/ServerSyncUtil.java
@@ -1,0 +1,19 @@
+package edu.berkeley.eecs.emission.cordova.serversync;
+
+import static edu.berkeley.eecs.emission.cordova.serversync.ServerSyncPlugin.AUTHORITY;
+
+import android.accounts.Account;
+import android.content.Context;
+import android.os.Bundle;
+
+/**
+ * Contains client-server synchronisation related methods to be used in native codes.
+ */
+public class ServerSyncUtil {
+
+  public static void syncData(Context context) {
+    Account account = ServerSyncPlugin.GetOrCreateSyncAccount(context);
+    new ServerSyncAdapter(context, true)
+      .onPerformSync(account, Bundle.EMPTY, AUTHORITY, null, null);
+  }
+}


### PR DESCRIPTION
This is the second part of a resolution for e-mission/e-mission-docs#686
The ServerSyncUtil.java file contains the `syncData()` method used in the` data-collection` plugins.
