### PR TITLE
Move `initWithConsent` function into the `SensorControlForegroundDele…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-serversync"
-        version="1.2.6">
+        version="1.2.7">
 
   <name>ServerSync</name>
   <description>Push and pull local data to the server</description>

--- a/src/ios/BEMActivitySync.h
+++ b/src/ios/BEMActivitySync.h
@@ -12,6 +12,5 @@
 typedef void (^CombinedArrayHandler)(NSArray* combinedArrayHandler);
 
 @interface BEMActivitySync: NSObject
-+ (void) initWithConsent;
 + (void) getCombinedArray:(NSArray*)locationArray withHandler:(CombinedArrayHandler)completionArray;
 @end

--- a/src/ios/BEMActivitySync.m
+++ b/src/ios/BEMActivitySync.m
@@ -14,7 +14,6 @@
 #import "BEMBuiltinUserCache.h"
 #import "SimpleLocation.h"
 #import "TimeQuery.h"
-#import "SensorControlBackgroundChecker.h"
 #import "MotionActivity.h"
 #import "BEMServerSyncCommunicationHelper.h"
 #import "LocationTrackingConfig.h"

--- a/src/ios/BEMActivitySync.m
+++ b/src/ios/BEMActivitySync.m
@@ -14,40 +14,13 @@
 #import "BEMBuiltinUserCache.h"
 #import "SimpleLocation.h"
 #import "TimeQuery.h"
-#import "TripDiarySettingsCheck.h"
+#import "SensorControlBackgroundChecker.h"
 #import "MotionActivity.h"
 #import "BEMServerSyncCommunicationHelper.h"
 #import "LocationTrackingConfig.h"
 #import <CoreMotion/CoreMotion.h>
 
 @implementation BEMActivitySync
-
-+ (void) initWithConsent {
-    CMMotionActivityManager* activityMgr = [[CMMotionActivityManager alloc] init];
-    NSOperationQueue* mq = [NSOperationQueue mainQueue];
-    NSDate* startDate = [NSDate new];
-    NSTimeInterval dayAgoSecs = 24 * 60 * 60;
-    NSDate* endDate = [NSDate dateWithTimeIntervalSinceNow:-(dayAgoSecs)];
-    [activityMgr queryActivityStartingFromDate:startDate toDate:endDate toQueue:mq withHandler:^(NSArray *activities, NSError *error) {
-        if (error == nil) {
-            [LocalNotificationManager addNotification:@"activity recognition works fine"];
-        } else {
-            [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Error %@ while reading activities, travel mode detection may be unavailable", error]];
-            NSString* title = NSLocalizedStringFromTable(@"error-reading-activities", @"DCLocalizable", nil);
-            NSString* message = NSLocalizedStringFromTable(@"travel-mode-unavailable", @"DCLocalizable", nil);
-
-            UIAlertController* alert = [UIAlertController alertControllerWithTitle:title
-                                       message:message
-                                       preferredStyle:UIAlertControllerStyleAlert];
-
-            UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault
-                handler:^(UIAlertAction * action) {
-            }];
-            [alert addAction:defaultAction];
-            [TripDiarySettingsCheck showSettingsAlert:alert];
-        }
-    }];
-}
 
 + (void) getCombinedArray:(NSArray*) locationArray withHandler:(CombinedArrayHandler)completionHandler {
     /*


### PR DESCRIPTION
…gate`

Move it to the foreground delegate instead to be consistent with the other
permission code, and to ensure that we can generate the appropriate callbacks,
similar to the existing location callbacks.