### PR TITLE
Construct all the server call URLs using string concatenation

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-serversync"
-        version="1.2.8">
+        version="1.2.9">
 
   <name>ServerSync</name>
   <description>Push and pull local data to the server</description>

--- a/src/ios/BEMServerSyncCommunicationHelper.m
+++ b/src/ios/BEMServerSyncCommunicationHelper.m
@@ -112,9 +112,8 @@ static NSString* kSetStatsPath = @"/stats/set";
     NSMutableDictionary *toPush = [[NSMutableDictionary alloc] init];
     [toPush setObject:entriesToPush forKey:@"phone_to_server"];
     
-    NSURL* kBaseURL = [[ConnectionSettings sharedInstance] getConnectUrl];
-    NSURL* kUsercachePutURL = [NSURL URLWithString:kUsercachePutPath
-                                 relativeToURL:kBaseURL];
+    NSString* kBaseURLString = [[ConnectionSettings sharedInstance] getConnectString];
+    NSURL* kUsercachePutURL = [NSURL URLWithString:[kBaseURLString stringByAppendingString:kUsercachePutPath]];
     
     CommunicationHelper *executor = [[CommunicationHelper alloc] initPost:kUsercachePutURL data:toPush completionHandler:completionHandler];
     [executor execute];
@@ -214,9 +213,8 @@ static NSString* kSetStatsPath = @"/stats/set";
 +(void)server_to_phone:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
     NSLog(@"CommunicationHelper.server_to_phone called!");
     NSMutableDictionary *blankDict = [[NSMutableDictionary alloc] init];
-    NSURL* kBaseURL = [[ConnectionSettings sharedInstance] getConnectUrl];
-    NSURL* kUsercacheGetURL = [NSURL URLWithString:kUsercacheGetPath
-                                            relativeToURL:kBaseURL];
+    NSString* kBaseURLString = [[ConnectionSettings sharedInstance] getConnectString];
+    NSURL* kUsercacheGetURL = [NSURL URLWithString:[kBaseURLString stringByAppendingString:kUsercacheGetPath]];
     CommunicationHelper *executor = [[CommunicationHelper alloc] initPost:kUsercacheGetURL data:blankDict completionHandler:completionHandler];
     [executor execute];
 }


### PR DESCRIPTION
Instead on the relativeURL method.

This is because the relative URL appraoch does not work on iOS even though the documentation says that it should

Relative URL doesn't work: https://github.com/e-mission/e-mission-docs/issues/732#issuecomment-1140181722
Appending strings does work: https://github.com/e-mission/e-mission-docs/issues/732#issuecomment-1140296951

Related updates: https://github.com/e-mission/cordova-connection-settings/releases/tag/v1.2.3