### PR TITLE
:alien: Support rename of JWTAuth to OPCodeAuth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-serversync",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Simple package that stores all the connection settings that need to be configured",
   "license": "BSD-3-clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-serversync"
-        version="1.2.9">
+        version="1.3.0">
 
   <name>ServerSync</name>
   <description>Push and pull local data to the server</description>

--- a/src/android/ServerSyncAdapter.java
+++ b/src/android/ServerSyncAdapter.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.Properties;
 
 import edu.berkeley.eecs.emission.cordova.connectionsettings.ConnectionSettings;
-import edu.berkeley.eecs.emission.cordova.jwtauth.AuthTokenCreationFactory;
-import edu.berkeley.eecs.emission.cordova.jwtauth.AuthTokenCreator;
+import edu.berkeley.eecs.emission.cordova.opcodeauth.AuthTokenCreationFactory;
+import edu.berkeley.eecs.emission.cordova.opcodeauth.AuthTokenCreator;
 import edu.berkeley.eecs.emission.cordova.tracker.location.TripDiaryStateMachineReceiver;
 import edu.berkeley.eecs.emission.cordova.tracker.sensors.BatteryUtils;
 import edu.berkeley.eecs.emission.R;

--- a/src/android/ServerSyncAdapter.java
+++ b/src/android/ServerSyncAdapter.java
@@ -105,7 +105,7 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
 		AuthTokenCreator ac = AuthTokenCreationFactory.getInstance(cachedContext);
 		// Get the list of uncategorized trips from the server
 		// hardcoding the URL and the userID for now since we are still using fake data
-		String userName = ac.getUserEmail().await().getEmail();
+		String userName = ac.getOPCode().await().getEmail();
 		System.out.println("real user name = "+userName);
 
 		if (userName == null || userName.trim().length() == 0) {


### PR DESCRIPTION
Since we are not supporting generic OpenID/JWT any more

Main change:
https://github.com/e-mission/cordova-jwt-auth/pull/46/commits/d95ffffd56ec0c986a6f05e2f1ed1d3a9a25fff1 in
https://github.com/e-mission/cordova-jwt-auth/pull/46