### PR TITLE
:alien: Use getOPCode instead of getToken

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-serversync"
-        version="1.3.1">
+        version="1.3.2">
 
   <name>ServerSync</name>
   <description>Push and pull local data to the server</description>

--- a/src/android/ServerSyncAdapter.java
+++ b/src/android/ServerSyncAdapter.java
@@ -105,7 +105,7 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
 		AuthTokenCreator ac = AuthTokenCreationFactory.getInstance(cachedContext);
 		// Get the list of uncategorized trips from the server
 		// hardcoding the URL and the userID for now since we are still using fake data
-		String userName = ac.getOPCode().await().getEmail();
+		String userName = ac.getOPCode().await().getOPCode();
 		System.out.println("real user name = "+userName);
 
 		if (userName == null || userName.trim().length() == 0) {
@@ -114,7 +114,7 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
 			return;
 		}
 		// First, get a token so that we can make the authorized calls to the server
-		String userToken = ac.getServerToken().await().getToken();
+		String userToken = ac.getOPCode().await().getOPCode();
 
 
 		/*


### PR DESCRIPTION
To be consistent with
https://github.com/e-mission/cordova-jwt-auth/pull/48

This is also part of the workaround for
https://github.com/e-mission/e-mission-docs/issues/930