### PR TITLE
🔥 Remove the `NEW_DATA` broadcast intent when we pull data from the s…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-serversync"
-        version="1.3.2">
+        version="1.3.3">
 
   <name>ServerSync</name>
   <description>Push and pull local data to the server</description>

--- a/src/android/ServerSyncAdapter.java
+++ b/src/android/ServerSyncAdapter.java
@@ -176,13 +176,6 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
 					new StatsEvent(cachedContext, R.string.pull_duration));
 		}
 
-		// We are sending this only locally, so we don't care about the URI and so on.
-        Intent localIntent = new Intent("edu.berkeley.eecs.emission.sync.NEW_DATA");
-        Bundle b = new Bundle();
-        b.putString( "userdata", "{}" );
-        localIntent.putExtras(b);
-        Log.i(cachedContext, TAG, "Finished sync, sending local broadcast");
-        LocalBroadcastManager.getInstance(cachedContext).sendBroadcastSync(localIntent);
 		biuc.putMessage(R.string.key_usercache_client_time,
 				new StatsEvent(cachedContext, R.string.sync_duration, to.elapsedSecs()));
 	}

--- a/src/ios/BEMServerSyncCommunicationHelper.m
+++ b/src/ios/BEMServerSyncCommunicationHelper.m
@@ -171,18 +171,7 @@ static NSString* kSetStatsPath = @"/stats/set";
                 StatsEvent* se = [[StatsEvent alloc] initForReading:@"sync_pull_list_size" withReading:newSectionCount];
                 [[BuiltinUserCache database] putMessage:@"key.usercache.client_time" value:se];
 
-                if (newSectionCount > 0) {
-                    // Note that we need to update the UI before calling the completion handler, otherwise
-                    // when the view appears, users won't see the newly fetched data!
-                    [[NSNotificationCenter defaultCenter] postNotificationName:BackgroundRefreshNewData
-                                                                        object:self];
-                    [[NSNotificationCenter defaultCenter] postNotificationName:@"edu.berkeley.eecs.emission.sync.NEW_DATA"
-                                                                        object:nil
-                                                                      userInfo:nil];
-                    [task setResult:@(TRUE)];
-                } else {
-                    [task setResult:@(TRUE)];
-                }
+                [task setResult:@(TRUE)];
             }
             StatsEvent* se = [[StatsEvent alloc] initForReading:@"pull_duration" withReading:[t elapsed_secs]];
             [[BuiltinUserCache database] putMessage:@"key.usercache.client_time" value:se];


### PR DESCRIPTION
…erver

- The intent does not have the package configured like all the other explicit intents
- The intent is currently unused since we do not read any data from the local cache
- Note that since we don't read any data from the local cache, we can also just stop returning any data from the server, and reduce power and data consumption. That is implemented in the related PR: https://github.com/e-mission/e-mission-server/pull/978