### PR TITLE
🔄🚚 Enable Deployment Config Auto Upgrade; Rename class names for clarity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-serversync",
-  "version": "1.3.1",
+  "version": "1.3.4",
   "description": "Simple package that stores all the connection settings that need to be configured",
   "license": "BSD-3-clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-serversync"
-        version="1.3.3">
+        version="1.3.4">
 
   <name>ServerSync</name>
   <description>Push and pull local data to the server</description>
@@ -84,9 +84,9 @@
     <source-file src="src/android/ServerSyncAdapter.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <source-file src="src/android/StubContentProvider.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <source-file src="src/android/SyncService.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
-    <source-file src="src/android/CommunicationHelper.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
+    <source-file src="src/android/ServerSyncCommunicationHelper.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <source-file src="src/android/ServerSyncPlugin.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
-    <source-file src="src/android/ConfigManager.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
+    <source-file src="src/android/ServerSyncConfigManager.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <source-file src="src/android/ServerSyncConfig.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <source-file src="src/android/ServerSyncUtil.java" target-dir="src/edu/berkeley/eecs/emission/cordova/serversync"/>
     <resource-file src="res/android/authenticator.xml" target="res/xml/authenticator.xml"/>

--- a/src/android/ServerSyncAdapter.java
+++ b/src/android/ServerSyncAdapter.java
@@ -133,7 +133,7 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
 			if (entriesToPush.length() == 0) {
 				System.out.println("No data to send, returning early!");
 			} else {
-				CommunicationHelper.phone_to_server(cachedContext, userToken, entriesToPush);
+				ServerSyncCommunicationHelper.phone_to_server(cachedContext, userToken, entriesToPush);
 				UserCache.TimeQuery tq = BuiltinUserCache.getTimeQuery(cachedContext, entriesToPush);
 				biuc.clearEntries(tq);
 				biuc.clearSupersededRWDocs(tq);
@@ -160,7 +160,7 @@ public class ServerSyncAdapter extends AbstractThreadedSyncAdapter {
 			Timer t = new Timer();
 			UserCache.TimeQuery tq = new UserCache.TimeQuery("write_ts", 0, System.currentTimeMillis()/1000);
 			biuc.clearObsoleteDocs(tq);
-			JSONArray entriesReceived = edu.berkeley.eecs.emission.cordova.serversync.CommunicationHelper.server_to_phone(
+			JSONArray entriesReceived = ServerSyncCommunicationHelper.server_to_phone(
 					cachedContext, userToken);
 			biuc.sync_server_to_phone(entriesReceived);
 			biuc.checkAfterPull();

--- a/src/android/ServerSyncCommunicationHelper.java
+++ b/src/android/ServerSyncCommunicationHelper.java
@@ -8,10 +8,11 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
+import edu.berkeley.eecs.emission.cordova.comm.CommunicationHelper;
 import edu.berkeley.eecs.emission.cordova.connectionsettings.ConnectionSettings;
 
-public class CommunicationHelper {
-    public static final String TAG = "CommunicationHelper";
+public class ServerSyncCommunicationHelper {
+    public static final String TAG = "ServerSyncCommunicationHelper";
 
     /*
      * Gets user cache information from server
@@ -21,7 +22,7 @@ public class CommunicationHelper {
             throws IOException, JSONException {
         String commuteTrackerHost = ConnectionSettings.getConnectURL(cachedContext);
         String fullURL = commuteTrackerHost + "/usercache/get";
-        String rawJSON = edu.berkeley.eecs.emission.cordova.comm.CommunicationHelper.getUserPersonalData(
+        String rawJSON = CommunicationHelper.getUserPersonalData(
                 cachedContext, fullURL, userToken);
         if (rawJSON.trim().length() == 0) {
             // We didn't get anything from the server, so let's return an empty array for now
@@ -38,7 +39,7 @@ public class CommunicationHelper {
     public static void phone_to_server(Context cachedContext, String userToken, JSONArray entryArr)
             throws IOException, JSONException {
         String commuteTrackerHost = ConnectionSettings.getConnectURL(cachedContext);
-        edu.berkeley.eecs.emission.cordova.comm.CommunicationHelper.pushJSON(
+        CommunicationHelper.pushJSON(
                 cachedContext, commuteTrackerHost + "/usercache/put",
                 userToken, "phone_to_server", entryArr);
     }

--- a/src/android/ServerSyncCommunicationHelper.java
+++ b/src/android/ServerSyncCommunicationHelper.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 
 import edu.berkeley.eecs.emission.cordova.comm.CommunicationHelper;
 import edu.berkeley.eecs.emission.cordova.connectionsettings.ConnectionSettings;
+import edu.berkeley.eecs.emission.cordova.tracker.TrackingConfigManager;
 
 public class ServerSyncCommunicationHelper {
     public static final String TAG = "ServerSyncCommunicationHelper";
@@ -39,8 +40,27 @@ public class ServerSyncCommunicationHelper {
     public static void phone_to_server(Context cachedContext, String userToken, JSONArray entryArr)
             throws IOException, JSONException {
         String commuteTrackerHost = ConnectionSettings.getConnectURL(cachedContext);
-        CommunicationHelper.pushJSON(
-                cachedContext, commuteTrackerHost + "/usercache/put",
-                userToken, "phone_to_server", entryArr);
+        JSONObject toPush = new JSONObject();
+        toPush.put("phone_to_server", entryArr);
+
+        JSONObject deploymentConfig = TrackingConfigManager.getDeploymentConfig(cachedContext);
+        if (deploymentConfig != null && deploymentConfig.has("version") && !deploymentConfig.isNull("version")) {
+            toPush.put("deployment_config_version", deploymentConfig.get("version"));
+        }
+        
+        try {
+            String appVersion = cachedContext.getPackageManager().getPackageInfo(cachedContext.getPackageName(), 0).versionName;
+            toPush.put("app_version", appVersion);
+        } catch (Exception e) {
+            Log.e(TAG, "Error getting app version", e);
+        }
+
+        String rawJSON = CommunicationHelper.pushGetJSON(cachedContext, commuteTrackerHost + "/usercache/put", toPush);
+        if (rawJSON != null && rawJSON.trim().length() > 0) {
+            JSONObject responseObj = new JSONObject(rawJSON);
+            if (responseObj.has("deployment_config") && !responseObj.isNull("deployment_config")) {
+                TrackingConfigManager.upgradeDeploymentConfig(cachedContext, responseObj.getJSONObject("deployment_config"));
+            }
+        }
     }
 }

--- a/src/android/ServerSyncConfigManager.java
+++ b/src/android/ServerSyncConfigManager.java
@@ -10,20 +10,20 @@ import edu.berkeley.eecs.emission.cordova.usercache.UserCacheFactory;
  * Created by shankari on 3/25/16.
  */
 
-public class ConfigManager {
-    private static ServerSyncConfig cachedConfig;
+public class ServerSyncConfigManager {
+    private static ServerSyncConfig cachedSyncConfig;
 
-    public static ServerSyncConfig getConfig(Context context) {
-        if (cachedConfig == null) {
-            cachedConfig = readFromCache(context);
-            if (cachedConfig == null) {
+    public static ServerSyncConfig getSyncConfig(Context context) {
+        if (cachedSyncConfig == null) {
+            cachedSyncConfig = readFromCache(context);
+            if (cachedSyncConfig == null) {
                 // This is still NULL, which means that there is no document in the usercache.
                 // Let us set it to the default settings
                 // we don't want to save it to the database because then it will look like a user override
-                cachedConfig = new ServerSyncConfig();
+                cachedSyncConfig = new ServerSyncConfig();
             }
         }
-        return cachedConfig;
+        return cachedSyncConfig;
     }
 
     private static ServerSyncConfig readFromCache(Context context) {
@@ -31,9 +31,9 @@ public class ConfigManager {
                 .getDocument(R.string.key_usercache_sync_config, ServerSyncConfig.class);
     }
 
-    protected static void updateConfig(Context context, ServerSyncConfig newConfig) {
+    protected static void updateSyncConfig(Context context, ServerSyncConfig newSyncConfig) {
         UserCacheFactory.getUserCache(context)
-                .putReadWriteDocument(R.string.key_usercache_sync_config, newConfig);
-        cachedConfig = newConfig;
+                .putReadWriteDocument(R.string.key_usercache_sync_config, newSyncConfig);
+        cachedSyncConfig = newSyncConfig;
     }
 }

--- a/src/android/ServerSyncPlugin.java
+++ b/src/android/ServerSyncPlugin.java
@@ -85,7 +85,7 @@ public class ServerSyncPlugin extends CordovaPlugin {
             return true;
         } else if (action.equals("getConfig")) {
             Context ctxt = cordova.getActivity();
-            ServerSyncConfig cfg = ConfigManager.getConfig(ctxt);
+            ServerSyncConfig cfg = ServerSyncConfigManager.getSyncConfig(ctxt);
             // Gson.toJson() represents a string and we are expecting an object in the interface
             callbackContext.success(new JSONObject(new Gson().toJson(cfg)));
             return true;
@@ -93,7 +93,7 @@ public class ServerSyncPlugin extends CordovaPlugin {
             Context ctxt = cordova.getActivity();
             JSONObject newConfig = data.getJSONObject(0);
             ServerSyncConfig cfg = new Gson().fromJson(newConfig.toString(), ServerSyncConfig.class);
-            ConfigManager.updateConfig(ctxt, cfg);
+            ServerSyncConfigManager.updateSyncConfig(ctxt, cfg);
             restartSync(ctxt);
             callbackContext.success();
             return true;
@@ -105,9 +105,9 @@ public class ServerSyncPlugin extends CordovaPlugin {
 
     protected void restartSync(Context ctxt) {
         System.out.println("Starting sync with interval "+
-                ConfigManager.getConfig(ctxt).getSyncInterval());
+                ServerSyncConfigManager.getSyncConfig(ctxt).getSyncInterval());
         ContentResolver.addPeriodicSync(mAccount, AUTHORITY, unusedExtras,
-                ConfigManager.getConfig(ctxt).getSyncInterval());
+                ServerSyncConfigManager.getSyncConfig(ctxt).getSyncInterval());
     }
 
 

--- a/src/ios/BEMServerSyncCommunicationHelper.m
+++ b/src/ios/BEMServerSyncCommunicationHelper.m
@@ -11,6 +11,7 @@
 #import <objc/runtime.h>
 #import "LocalNotificationManager.h"
 
+#import "BEMTrackingConfigManager.h"
 #import "SimpleLocation.h"
 #import "TimeQuery.h"
 #import "MotionActivity.h"
@@ -85,32 +86,47 @@ static NSString* kSetStatsPath = @"/stats/set";
                                                    @"No data to send, returning early"] showUI:FALSE];
     } else {
         [self phone_to_server:entriesToPush
-                             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                 // Only delete trips after they have been successfully pushed
-                                 if (error == nil) {
-                                 [LocalNotificationManager addNotification:[NSString stringWithFormat:
-                                                                            @"successfully pushed %ld entries to the server",
-                                                                            (unsigned long)entriesToPush.count]
-                                                                    showUI:TRUE];
-                                     [[BuiltinUserCache database] clearEntries:tq];
-                                     // rw-docs are pushed like entries, so let's handle them here
-                                     [[BuiltinUserCache database] clearSupersededRWDocs:tq];
-                                     StatsEvent* se = [[StatsEvent alloc] initForReading:@"push_duration" withReading:[t elapsed_secs]];
-                                     [[BuiltinUserCache database] putMessage:@"key.usercache.client_time" value:se];
-                                 } else {
-                                     [LocalNotificationManager addNotification:[NSString stringWithFormat:
-                                                                                @"Got error %@ while pushing changes to server, retaining data", error] showUI:TRUE];
-                                     StatsEvent* se = [[StatsEvent alloc] initForReading:@"push_duration" withReading:[t elapsed_secs]];
-                                     [[BuiltinUserCache database] putMessage:@"key.usercache.client_time" value:se];
-                                 }
-                                 [task setResult:@(TRUE)];
-                             }];
+            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                // Only delete trips after they have been successfully pushed
+                if (error == nil) {
+                    [LocalNotificationManager addNotification:[NSString stringWithFormat: @"successfully pushed %ld entries to the server",
+                                                                        (unsigned long)entriesToPush.count]
+                                              showUI:TRUE];
+                    [[BuiltinUserCache database] clearEntries:tq];
+                    // rw-docs are pushed like entries, so let's handle them here
+                    [[BuiltinUserCache database] clearSupersededRWDocs:tq];
+                    StatsEvent* se = [[StatsEvent alloc] initForReading:@"push_duration" withReading:[t elapsed_secs]];
+                    [[BuiltinUserCache database] putMessage:@"key.usercache.client_time" value:se];
+
+                    // if response data JSON has "deployment_config", call BEMTrackingConfigManager upgradeDeploymentConfig
+                    NSError *parseError = nil;
+                    NSDictionary *dataDict = [NSJSONSerialization JSONObjectWithData:data
+                                                                  options:0
+                                                                  error:&parseError];
+                    if (parseError == nil && dataDict[@"deployment_config"] != nil) {
+                        [BEMTrackingConfigManager upgradeDeploymentConfig:dataDict[@"deployment_config"]];
+                    }
+                } else {
+                    [LocalNotificationManager addNotification:[NSString stringWithFormat: @"Got error %@ while pushing changes to server, retaining data", error] showUI:TRUE];
+                    StatsEvent* se = [[StatsEvent alloc] initForReading:@"push_duration" withReading:[t elapsed_secs]];
+                    [[BuiltinUserCache database] putMessage:@"key.usercache.client_time" value:se];
+                }
+                [task setResult:@(TRUE)];
+            }];
     }
 }
 
 +(void)phone_to_server:(NSArray *)entriesToPush completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
     NSMutableDictionary *toPush = [[NSMutableDictionary alloc] init];
     [toPush setObject:entriesToPush forKey:@"phone_to_server"];
+
+    NSDictionary *config = [BEMTrackingConfigManager getDeploymentConfig];
+    [toPush setObject:config[@"version"] forKey:@"deployment_config_version"];
+    
+    NSString *emissionInfoPath = [[NSBundle mainBundle] pathForResource:@"Info" ofType:@"plist"];
+    NSDictionary *infoDict = [[NSDictionary alloc] initWithContentsOfFile:emissionInfoPath];
+    NSString* appVersion = [infoDict objectForKey:@"CFBundleShortVersionString"];
+    [toPush setObject:appVersion forKey:@"app_version"];
     
     NSString* kBaseURLString = [[ConnectionSettings sharedInstance] getConnectString];
     NSURL* kUsercachePutURL = [NSURL URLWithString:[kBaseURLString stringByAppendingString:kUsercachePutPath]];

--- a/src/ios/BEMServerSyncConfigManager.h
+++ b/src/ios/BEMServerSyncConfigManager.h
@@ -12,6 +12,6 @@
 @interface BEMServerSyncConfigManager : NSObject
 
 + (BEMServerSyncConfig*) instance;
-+ (void) updateConfig:(BEMServerSyncConfig*) newConfig;
++ (void) updateSyncConfig:(BEMServerSyncConfig*) newSyncConfig;
 
 @end

--- a/src/ios/BEMServerSyncConfigManager.m
+++ b/src/ios/BEMServerSyncConfigManager.m
@@ -15,6 +15,7 @@ static BEMServerSyncConfig *_instance;
 
 @implementation BEMServerSyncConfigManager
 
+// corresponds to getSyncConfig in ServerSyncConfigManager.java
 + (BEMServerSyncConfig*) instance {
     if (_instance == NULL) {
         _instance = [self readFromCache];
@@ -32,9 +33,9 @@ static BEMServerSyncConfig *_instance;
     return (BEMServerSyncConfig*)[[BuiltinUserCache database] getDocument:SENSOR_CONFIG_KEY wrapperClass:[BEMServerSyncConfig class]];
 }
 
-+ (void) updateConfig:(BEMServerSyncConfig*) newConfig {
-    [[BuiltinUserCache database] putReadWriteDocument:SENSOR_CONFIG_KEY value:newConfig];
-    _instance = newConfig;
++ (void) updateSyncConfig:(BEMServerSyncConfig*) newSyncConfig {
+    [[BuiltinUserCache database] putReadWriteDocument:SENSOR_CONFIG_KEY value:newSyncConfig];
+    _instance = newSyncConfig;
 }
 
 @end

--- a/src/ios/BEMServerSyncPlugin.m
+++ b/src/ios/BEMServerSyncPlugin.m
@@ -65,7 +65,7 @@
         NSDictionary* newDict = [[command arguments] objectAtIndex:0];
         BEMServerSyncConfig* newCfg = [BEMServerSyncConfig new];
         [DataUtils dictToWrapper:newDict wrapper:newCfg];
-        [BEMServerSyncConfigManager updateConfig:newCfg];
+        [BEMServerSyncConfigManager updateSyncConfig:newCfg];
         [BEMServerSyncPlugin applySync];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
#### 🚚 Rename overlapping class names and methods for clarity

> We have classes called ConfigManager in e-mission-data-collection and cordova-server-sync, and we have classes called CommunicationHelper in cordova-server-sync and cordova-server-communication.
> Renaming these to be more explicit clears up confusion, makes some of the imports clearer, and avoids any potential conflicts (especially if we consolidate any of these plugins to a common repo later on when we migrate the plugins to RN)

<hr>

#### 🔄 Enable version-aware auto config upgrade on usercache put

> To keep deployment config version in sync, we will include `deployment_config_version` and `app_version` in all /usercache/put requests.
> If the server determines a config update is needed, it will include the appropriate "deployment_config" in the response and we will call upgradeDeploymentConfig on receipt

<hr>

#### 1.3.4